### PR TITLE
[improve]no subscribe callback when no pubsub component configurated.

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -237,6 +237,9 @@ func (m *MosnRuntime) initPubSubs(factorys ...*pubsub_service.Factory) error {
 
 func (m *MosnRuntime) startSubscribing() error {
 	// 1. check if there is no need to do it
+	if len(m.pubSubs) == 0 {
+		return nil
+	}
 	topicRoutes, err := m.getInterestedTopics()
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read contributing.md before commit pull request.
-->

**What this PR does**:
no subscribe callback when no pubsub component configurated.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
When no pubsub component configurated,runtime will still callback app to list subscription topics.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```