### PR TITLE
return error when panic

### DIFF
--- a/components/rpc/invoker/mosn/mosninvoker.go
+++ b/components/rpc/invoker/mosn/mosninvoker.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"mosn.io/layotto/components/rpc"
 	"mosn.io/layotto/components/rpc/callback"
@@ -75,10 +76,11 @@ func (m *mosnInvoker) Init(conf rpc.RpcConfig) error {
 	return nil
 }
 
-func (m *mosnInvoker) Invoke(ctx context.Context, req *rpc.RPCRequest) (*rpc.RPCResponse, error) {
+func (m *mosnInvoker) Invoke(ctx context.Context, req *rpc.RPCRequest) (resp *rpc.RPCResponse, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.DefaultLogger.Errorf("[runtime][rpc]mosn invoker panic: %v", r)
+			err = fmt.Errorf("[runtime][rpc]mosn invoker panic: %v", r)
+			log.DefaultLogger.Errorf("%v", err)
 		}
 	}()
 
@@ -87,13 +89,13 @@ func (m *mosnInvoker) Invoke(ctx context.Context, req *rpc.RPCRequest) (*rpc.RPC
 	}
 	req.Ctx = ctx
 	log.DefaultLogger.Debugf("[runtime][rpc]request %+v", req)
-	req, err := m.cb.BeforeInvoke(req)
+	req, err = m.cb.BeforeInvoke(req)
 	if err != nil {
 		log.DefaultLogger.Errorf("[runtime][rpc]before filter error %s", err.Error())
 		return nil, err
 	}
 
-	resp, err := m.channel.Do(req)
+	resp, err = m.channel.Do(req)
 	if err != nil {
 		log.DefaultLogger.Errorf("[runtime][rpc]error %s", err.Error())
 		return nil, err

--- a/components/rpc/invoker/mosn/mosninvoker_test.go
+++ b/components/rpc/invoker/mosn/mosninvoker_test.go
@@ -94,6 +94,22 @@ func Test_mosnInvoker_Invoke(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, "hello world!", string(rsp.Data))
 	})
+
+	t.Run("panic", func(t *testing.T) {
+		invoker := NewMosnInvoker()
+
+		// miss call Init(), invoker.ch will be nil
+		req := &rpc.RPCRequest{
+			Ctx:     context.Background(),
+			Id:      "1",
+			Timeout: 100,
+			Method:  "Hello",
+			Data:    []byte("hello"),
+		}
+		_, err := invoker.Invoke(context.Background(), req)
+		assert.NotNil(t, err)
+		assert.Equal(t, "[runtime][rpc]mosn invoker panic: runtime error: invalid memory address or nil pointer dereference", err.Error())
+	})
 }
 
 type fakeChannel struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read contributing.md before commit pull request.
-->

**What this PR does**:
When Invoke method panic, return error instead of return nil

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/mosn/layotto/issues/114

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```