### PR TITLE
Ignore the build result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/bundles
 .idea
 .test
 .out
+layotto
 !./.gitignore
 IMAGEBUILD/
 coverage.txt


### PR DESCRIPTION
Ignore the build result in case of add the build result to the repository.

Fix issue #218 