### PR TITLE
[WIP]feat(layotto-lite): use layotto as a sdk ,not a sidecar

### DIFF
--- a/sdk/go-sdk/client/client_factory.go
+++ b/sdk/go-sdk/client/client_factory.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Layotto Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+	runtimev1pb "mosn.io/layotto/spec/proto/runtime/v1"
+)
+
+var factory ClientFactory = &ClientFactoryImpl{}
+
+func RegisterClientFactory(cf ClientFactory) {
+	factory = cf
+}
+
+type ClientFactory interface {
+	NewClientWithAddress(address string) (*grpc.ClientConn, runtimev1pb.RuntimeClient, error)
+}
+
+type ClientFactoryImpl struct {
+}
+
+// NewClientWithAddress instantiates runtime using specific address (including port).
+func (cf *ClientFactoryImpl) NewClientWithAddress(address string) (*grpc.ClientConn, runtimev1pb.RuntimeClient, error) {
+	conn, err := grpc.Dial(address, grpc.WithInsecure())
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "error creating connection to '%s': %v", address, err)
+	}
+
+	return conn, runtimev1pb.NewRuntimeClient(conn), nil
+}

--- a/sdk/go-sdk/client/client_test.go
+++ b/sdk/go-sdk/client/client_test.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
@@ -102,8 +103,20 @@ func getTestClient(ctx context.Context) (client Client, closer func()) {
 		s.Stop()
 	}
 
-	client = NewClientWithConnection(c)
+	client, _ = newClientWithConnection(c)
 	return
+}
+
+// NewClientWithConnection instantiates runtime client using specific connection.
+func newClientWithConnection(conn *grpc.ClientConn) (Client, error) {
+	if conn == nil {
+		return nil, errors.New("conn shouldn't be nil")
+	}
+	cli := runtimev1pb.NewRuntimeClient(conn)
+	return &GRPCClient{
+		connection:  conn,
+		protoClient: cli,
+	}, nil
 }
 
 type testRuntimeServer struct {

--- a/sdk/layotto-lite/client/client_factory.go
+++ b/sdk/layotto-lite/client/client_factory.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Layotto Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"google.golang.org/grpc"
+	"mosn.io/layotto/sdk/go-sdk/client"
+	runtimev1pb "mosn.io/layotto/spec/proto/runtime/v1"
+)
+
+func init() {
+	client.RegisterClientFactory(&localClientFactory{})
+}
+
+type localClientFactory struct {
+}
+
+func (l *localClientFactory) NewClientWithAddress(address string) (*grpc.ClientConn, runtimev1pb.RuntimeClient, error) {
+	return nil, newLocalRuntimeClient(), nil
+}
+
+func (l *localClientFactory) NewClientWithConnection(conn *grpc.ClientConn) (runtimev1pb.RuntimeClient, error) {
+	return &localRuntimeClient{}, nil
+}

--- a/sdk/layotto-lite/client/runtime_client.go
+++ b/sdk/layotto-lite/client/runtime_client.go
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2021 Layotto Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"context"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+	layotto_grpc "mosn.io/layotto/pkg/grpc"
+	runtimev1pb "mosn.io/layotto/spec/proto/runtime/v1"
+)
+
+// localRuntimeClient implements RuntimeClient interface
+// and do in-process message passing
+type localRuntimeClient struct {
+	api layotto_grpc.API
+}
+
+func newLocalRuntimeClient() *localRuntimeClient {
+	api := layotto_grpc.NewAPI(appId, hellos, configStores, rpcs, pubSubs, stateStores, files, lockStores, sequencers, sendToOutputBindingFn)
+	return &localRuntimeClient{
+		api: api,
+	}
+}
+
+func (l *localRuntimeClient) SayHello(ctx context.Context, in *runtimev1pb.SayHelloRequest, opts ...grpc.CallOption) (*runtimev1pb.SayHelloResponse, error) {
+	return l.api.SayHello(ctx, in)
+}
+
+func (l *localRuntimeClient) InvokeService(ctx context.Context, in *runtimev1pb.InvokeServiceRequest, opts ...grpc.CallOption) (*runtimev1pb.InvokeResponse, error) {
+	return l.api.InvokeService(ctx, in)
+}
+
+func (l *localRuntimeClient) GetConfiguration(ctx context.Context, in *runtimev1pb.GetConfigurationRequest, opts ...grpc.CallOption) (*runtimev1pb.GetConfigurationResponse, error) {
+	return l.api.GetConfiguration(ctx, in)
+}
+
+func (l *localRuntimeClient) SaveConfiguration(ctx context.Context, in *runtimev1pb.SaveConfigurationRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return l.api.SaveConfiguration(ctx, in)
+}
+
+func (l *localRuntimeClient) DeleteConfiguration(ctx context.Context, in *runtimev1pb.DeleteConfigurationRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return l.api.DeleteConfiguration(ctx, in)
+}
+
+func (l *localRuntimeClient) SubscribeConfiguration(ctx context.Context, opts ...grpc.CallOption) (runtimev1pb.Runtime_SubscribeConfigurationClient, error) {
+	panic("implement me")
+}
+
+func (l *localRuntimeClient) TryLock(ctx context.Context, in *runtimev1pb.TryLockRequest, opts ...grpc.CallOption) (*runtimev1pb.TryLockResponse, error) {
+	return l.api.TryLock(ctx, in)
+}
+
+func (l *localRuntimeClient) Unlock(ctx context.Context, in *runtimev1pb.UnlockRequest, opts ...grpc.CallOption) (*runtimev1pb.UnlockResponse, error) {
+	return l.api.Unlock(ctx, in)
+}
+
+func (l *localRuntimeClient) GetNextId(ctx context.Context, in *runtimev1pb.GetNextIdRequest, opts ...grpc.CallOption) (*runtimev1pb.GetNextIdResponse, error) {
+	return l.api.GetNextId(ctx, in)
+}
+
+func (l *localRuntimeClient) GetState(ctx context.Context, in *runtimev1pb.GetStateRequest, opts ...grpc.CallOption) (*runtimev1pb.GetStateResponse, error) {
+	return l.api.GetState(ctx, in)
+}
+
+func (l *localRuntimeClient) GetBulkState(ctx context.Context, in *runtimev1pb.GetBulkStateRequest, opts ...grpc.CallOption) (*runtimev1pb.GetBulkStateResponse, error) {
+	return l.api.GetBulkState(ctx, in)
+}
+
+func (l *localRuntimeClient) SaveState(ctx context.Context, in *runtimev1pb.SaveStateRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return l.api.SaveState(ctx, in)
+}
+
+func (l *localRuntimeClient) DeleteState(ctx context.Context, in *runtimev1pb.DeleteStateRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return l.api.DeleteState(ctx, in)
+}
+
+func (l *localRuntimeClient) DeleteBulkState(ctx context.Context, in *runtimev1pb.DeleteBulkStateRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return l.api.DeleteBulkState(ctx, in)
+}
+
+func (l *localRuntimeClient) ExecuteStateTransaction(ctx context.Context, in *runtimev1pb.ExecuteStateTransactionRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return l.api.ExecuteStateTransaction(ctx, in)
+}
+
+func (l *localRuntimeClient) PublishEvent(ctx context.Context, in *runtimev1pb.PublishEventRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return l.api.PublishEvent(ctx, in)
+}
+
+func (l *localRuntimeClient) GetFile(ctx context.Context, in *runtimev1pb.GetFileRequest, opts ...grpc.CallOption) (runtimev1pb.Runtime_GetFileClient, error) {
+	panic("implement me")
+}
+
+func (l *localRuntimeClient) PutFile(ctx context.Context, opts ...grpc.CallOption) (runtimev1pb.Runtime_PutFileClient, error) {
+	panic("implement me")
+}
+
+func (l *localRuntimeClient) ListFile(ctx context.Context, in *runtimev1pb.ListFileRequest, opts ...grpc.CallOption) (*runtimev1pb.ListFileResp, error) {
+	panic("implement me")
+}
+
+func (l *localRuntimeClient) DelFile(ctx context.Context, in *runtimev1pb.DelFileRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return l.api.DelFile(ctx, in)
+}
+
+func (l *localRuntimeClient) InvokeBinding(ctx context.Context, in *runtimev1pb.InvokeBindingRequest, opts ...grpc.CallOption) (*runtimev1pb.InvokeBindingResponse, error) {
+	return l.api.InvokeBinding(ctx, in)
+}

--- a/sdk/layotto-lite/client/types.go
+++ b/sdk/layotto-lite/client/types.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 Layotto Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"github.com/dapr/components-contrib/bindings"
+	"github.com/dapr/components-contrib/pubsub"
+	"github.com/dapr/components-contrib/state"
+	"mosn.io/layotto/components/configstores"
+	"mosn.io/layotto/components/file"
+	"mosn.io/layotto/components/hello"
+	"mosn.io/layotto/components/lock"
+	"mosn.io/layotto/components/rpc"
+	"mosn.io/layotto/components/sequencer"
+)
+
+var (
+	appId                 = ""
+	hellos                = make(map[string]hello.HelloService)
+	configStores          = make(map[string]configstores.Store)
+	rpcs                  = make(map[string]rpc.Invoker)
+	pubSubs               = make(map[string]pubsub.PubSub)
+	stateStores           = make(map[string]state.Store)
+	files                 = make(map[string]file.File)
+	lockStores            = make(map[string]lock.LockStore)
+	sequencers            = make(map[string]sequencer.Store)
+	sendToOutputBindingFn func(name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
+)
+
+func RegisterAppId(myAppId string) {
+	appId = myAppId
+}
+
+func RegisterHello(name string, service hello.HelloService) {
+	hellos[name] = service
+}
+
+func RegisterConfigStores(name string, service configstores.Store) {
+	configStores[name] = service
+}
+
+func RegisterRpcs(name string, service rpc.Invoker) {
+	rpcs[name] = service
+}
+
+func RegisterPubsubs(name string, service pubsub.PubSub) {
+	pubSubs[name] = service
+}
+
+func RegisterStateStores(name string, service state.Store) {
+	stateStores[name] = service
+}
+
+func RegisterFiles(name string, service file.File) {
+	files[name] = service
+}
+
+func RegisterLockStores(name string, service lock.LockStore) {
+	lockStores[name] = service
+}
+
+func RegisterSequencers(name string, service sequencer.Store) {
+	sequencers[name] = service
+}
+
+func RegisterSendToOutputBindingFn(fn func(name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)) {
+	sendToOutputBindingFn = fn
+}

--- a/sdk/layotto-lite/go.mod
+++ b/sdk/layotto-lite/go.mod
@@ -1,0 +1,17 @@
+module mosn.io/layotto/sdk/go-layotto-init
+
+go 1.14
+
+require (
+	mosn.io/layotto v0.2.1-0.20211015040910-1cce41398cee
+	mosn.io/layotto/components v0.0.0-20211020084508-6f5ee3cfeba0
+	mosn.io/layotto/sdk/go-sdk v0.0.0-20211020084508-6f5ee3cfeba0
+	mosn.io/layotto/spec v0.0.0-20211020084508-6f5ee3cfeba0
+)
+
+replace (
+	mosn.io/layotto => ../../
+	mosn.io/layotto/components => ../../components
+	mosn.io/layotto/sdk/go-sdk => ../go-sdk
+	mosn.io/layotto/spec => ../../spec
+)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read contributing.md before commit pull request.
-->

**What this PR does**:
I want to develop a new go packae called `layotto-lite` , which aims to give users another choice: 
use layotto as a sdk ,not a sidecar

- [x] refactor go client and remove redundent constructor function 
- [x] make go client easy to do DI(dependency injection)
- [x] layotto-lite support grpc API without stream
- [ ] add design doc
- [ ] component initialization
- [ ] layotto-lite support grpc stream 
- [ ]  layotto-lite support appcallback
- [ ] add examples
- [ ] split layotto into two modules
- [ ] make layotto-lite smaller
- [ ] add doc

RPC api won't be involved in this first PR

**Why I want to do this**:
See section 5 in  #309 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```