### PR TITLE
fix zk lock ut

### DIFF
--- a/components/lock/zookeeper/zookeeper_lock_test.go
+++ b/components/lock/zookeeper/zookeeper_lock_test.go
@@ -53,11 +53,8 @@ func TestZookeeperLock_ALock_AUnlock(t *testing.T) {
 	lockConn := utils.NewMockZKConnection(ctrl)
 	factory := utils.NewMockConnectionFactory(ctrl)
 	path := "/" + resouseId
-	factory.EXPECT().NewConnection(time.Duration(expireTime)*time.Second, comp.metadata).Return(lockConn, nil).Times(2)
-
+	factory.EXPECT().NewConnection(time.Duration(expireTime)*time.Second, comp.metadata).Return(lockConn, nil).Times(1)
 	lockConn.EXPECT().Create(path, []byte(lockOwerA), int32(zk.FlagEphemeral), zk.WorldACL(zk.PermAll)).Return("", nil).Times(1)
-	lockConn.EXPECT().Close().Return().Times(1)
-
 	unlockConn.EXPECT().Get(path).Return([]byte(lockOwerA), &zk.Stat{Version: 123}, nil).Times(1)
 	unlockConn.EXPECT().Delete(path, int32(123)).Return(nil).Times(1)
 
@@ -92,13 +89,9 @@ func TestZookeeperLock_ALock_BUnlock(t *testing.T) {
 	lockConn := utils.NewMockZKConnection(ctrl)
 	factory := utils.NewMockConnectionFactory(ctrl)
 	path := "/" + resouseId
-	factory.EXPECT().NewConnection(time.Duration(expireTime)*time.Second, comp.metadata).Return(lockConn, nil).Times(2)
-
+	factory.EXPECT().NewConnection(time.Duration(expireTime)*time.Second, comp.metadata).Return(lockConn, nil).Times(1)
 	lockConn.EXPECT().Create(path, []byte(lockOwerA), int32(zk.FlagEphemeral), zk.WorldACL(zk.PermAll)).Return("", nil).Times(1)
-	lockConn.EXPECT().Close().Return().Times(1)
-
 	unlockConn.EXPECT().Get(path).Return([]byte(lockOwerA), &zk.Stat{Version: 123}, nil).Times(1)
-	unlockConn.EXPECT().Delete(path, int32(123)).Return(nil).Times(1)
 
 	comp.unlockConn = unlockConn
 	comp.factory = factory
@@ -137,12 +130,12 @@ func TestZookeeperLock_ALock_BLock_AUnlock_BLock_BUnlock(t *testing.T) {
 	lockConn.EXPECT().Create(path, []byte(lockOwerA), int32(zk.FlagEphemeral), zk.WorldACL(zk.PermAll)).Return("", nil).Times(1)
 	lockConn.EXPECT().Create(path, []byte(lockOwerB), int32(zk.FlagEphemeral), zk.WorldACL(zk.PermAll)).Return("", zk.ErrNodeExists).Times(1)
 	lockConn.EXPECT().Create(path, []byte(lockOwerB), int32(zk.FlagEphemeral), zk.WorldACL(zk.PermAll)).Return("", nil).Times(1)
-	lockConn.EXPECT().Close().Return().Times(5)
+	lockConn.EXPECT().Close().Return().Times(1)
 
 	unlockConn.EXPECT().Get(path).Return([]byte(lockOwerA), &zk.Stat{Version: 123}, nil).Times(1)
 	unlockConn.EXPECT().Get(path).Return([]byte(lockOwerB), &zk.Stat{Version: 124}, nil).Times(1)
-	unlockConn.EXPECT().Delete(path, int32(123)).Return(nil).Times(2)
-	unlockConn.EXPECT().Delete(path, int32(124)).Return(nil).Times(2)
+	unlockConn.EXPECT().Delete(path, int32(123)).Return(nil).Times(1)
+	unlockConn.EXPECT().Delete(path, int32(124)).Return(nil).Times(1)
 
 	comp.unlockConn = unlockConn
 	comp.factory = factory


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read contributing.md before commit pull request.
-->

**What this PR does**:
fix zk lock ut fail. New version of gomock requires  the expected call times  must equals the real call times.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #363 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```