### PR TITLE
feat(config.json): schema change

### DIFF
--- a/configs/config_apollo.json
+++ b/configs/config_apollo.json
@@ -33,7 +33,7 @@
                           "hello": "greeting"
                         }
                       },
-                      "config_stores": {
+                      "config_store": {
                         "apollo": {
                           "address": [
                             "http://106.54.227.205:8080"

--- a/configs/config_apollo_health.json
+++ b/configs/config_apollo_health.json
@@ -38,7 +38,7 @@
                           "hello": "greeting"
                         }
                       },
-                      "config_stores": {
+                      "config_store": {
                         "apollo": {
                           "address": [
                             "http://106.54.227.205:8080"

--- a/configs/config_apollo_health_mq.json
+++ b/configs/config_apollo_health_mq.json
@@ -38,7 +38,7 @@
                           "hello": "greeting"
                         }
                       },
-                      "config_stores": {
+                      "config_store": {
                         "apollo": {
                           "address": [
                             "http://106.54.227.205:8080"

--- a/configs/config_file.json
+++ b/configs/config_file.json
@@ -21,7 +21,7 @@
                           "hello": "greeting"
                         }
                       },
-                      "files": {
+                      "file": {
                         "minioOSS": {
                           "metadata":[
                             {

--- a/configs/config_integration_redis_etcd.json
+++ b/configs/config_integration_redis_etcd.json
@@ -72,7 +72,7 @@
                           }
                         }
                       },
-                      "config_stores": {
+                      "config_store": {
                         "etcd": {
                           "address": [
                             "127.0.0.1:2379"

--- a/configs/runtime_config.json
+++ b/configs/runtime_config.json
@@ -21,7 +21,7 @@
                           "hello": "greeting"
                         }
                       },
-                      "config_stores": {
+                      "config_store": {
                         "etcd": {
                           "address": [
                             "127.0.0.1:2379"

--- a/configs/wrong/config_apollo_health.json
+++ b/configs/wrong/config_apollo_health.json
@@ -38,7 +38,7 @@
                           "hello": "greeting"
                         }
                       },
-                      "config_stores": {
+                      "config_store": {
                         "apollo": {
                           "address": [
                             "http://106.54.227.205:8080"

--- a/docs/en/component_specs/state/common.md
+++ b/docs/en/component_specs/state/common.md
@@ -37,11 +37,11 @@ The common configuration items of different State components are:
 
 the `keyPrefix` field supports the following key prefix strategies:
 
-* **`appid`** - This is the default policy. The key passed in by the user will eventually be saved as `current appid||key`
+* **`appid`** - The key passed in by the user will eventually be saved as `current appid||key`
 
 * **`name`** - This setting uses the name of the component as a prefix. For example, the redis component will store the key passed in by the user as `redis||key`
 
-* **`none`** - No prefix will be added.
+* **`none`** - No prefix will be added. **This is the default policy.**
 
 * Any other string that does not contain `||`. For example, if the keyPrefix is configured as "abc", the key passed in by the user will eventually be saved as `abc||key`
 

--- a/docs/en/start/configuration/start.md
+++ b/docs/en/start/configuration/start.md
@@ -4,7 +4,7 @@ This example shows how to add, delete, modify, and watch the etcd configuration 
 
 Please install [Docker](https://www.docker.com/get-started) software on your machine in advance.
 
-[Config file](https://github.com/mosn/layotto/blob/main/configs/runtime_config.json) defines using etcd in config_stores section, and users can change the configuration file to the configuration center they want (currently supports etcd and apollo).
+[Config file](https://github.com/mosn/layotto/blob/main/configs/runtime_config.json) defines using etcd in config_store section, and users can change the configuration file to the configuration center they want (currently supports etcd and apollo).
 
 ### Build docker image
 

--- a/docs/zh/component_specs/file/common.md
+++ b/docs/zh/component_specs/file/common.md
@@ -26,7 +26,7 @@ json配置文件有如下结构：
 
 ```golang
     type FileConfig struct {
-	Metadata json.RawMessage
+	    Metadata json.RawMessage
     }
 
     Files   map[string]file.FileConfig          `json:"file"`

--- a/docs/zh/component_specs/file/common.md
+++ b/docs/zh/component_specs/file/common.md
@@ -5,7 +5,7 @@
 json配置文件有如下结构：
 
 ```json
-"files": {
+"file": {
     "aliOSS": {
         "metadata":[
                 {
@@ -29,13 +29,13 @@ json配置文件有如下结构：
 	Metadata json.RawMessage
     }
 
-    Files   map[string]file.FileConfig          `json:"files"`
+    Files   map[string]file.FileConfig          `json:"file"`
 ```
 
 上面的Files是一个map,key为component的名字，比如上述json的aliOSS，component的配置没有具体的格式限制，不同component可以根据需求自己定义，比如:
 
 ```json
-"files": {
+"file": {
     "localFile": {
       "group":{
         "name": "group1"

--- a/docs/zh/component_specs/state/common.md
+++ b/docs/zh/component_specs/state/common.md
@@ -38,11 +38,11 @@ json配置文件有如下结构：
 
 keyPrefix支持以下键前缀策略:
 
-* **`appid`** - 这是默认策略。用户传入的key最终将被保存为`当前appid||key`
+* **`appid`** - 用户传入的key最终将被保存为`当前appid||key`
 
 * **`name`** - 此设置使用组件名称作为前缀。 比如redis组件会将用户传入的key存储为`redis||key`
 
-* **`none`** - 此设置不使用前缀。
+* **`none`** - 不给 key 添加前缀。**这是默认策略。**
 
 *  其他任意不含||的字符串.比如keyPrefix配置成"abc",那么用户传入的key最终将被保存为`abc||key`
 

--- a/docs/zh/design/actuator/grpc-design-doc.md
+++ b/docs/zh/design/actuator/grpc-design-doc.md
@@ -76,7 +76,7 @@ func MyFunc(_ json.RawMessage) *grpc.Server {
 												"hello": "greeting"
 											}
 										},
-										"config_stores": {
+										"config_store": {
 											"etcd": {
 												"address": ["127.0.0.1:2379"],
 												"timeout": "10"

--- a/docs/zh/design/file/file-design.md
+++ b/docs/zh/design/file/file-design.md
@@ -119,7 +119,7 @@ Put接口入参主要有三个，多了一个data字段用来传输文件内容�
 ```protobuf
 
 {
-    "files": {
+    "file": {
       "aliOSS": {
         "metadata":[
           {

--- a/docs/zh/start/configuration/start.md
+++ b/docs/zh/start/configuration/start.md
@@ -1,7 +1,7 @@
 # 使用Configuration API调用Etcd配置中心
 
 该示例展示了如何通过Layotto，对etcd配置中心进行增删改查以及watch的过程。请提前在本机上安装[Docker](https://www.docker.com/get-started) 软件。
-[config文件](https://github.com/mosn/layotto/blob/main/configs/runtime_config.json) 在config_stores中定义了etcd，用户可以更改配置文件为自己想要的配置中心（目前支持etcd和apollo）。
+[config文件](https://github.com/mosn/layotto/blob/main/configs/runtime_config.json) 在config_store中定义了etcd，用户可以更改配置文件为自己想要的配置中心（目前支持etcd和apollo）。
 
 ### 生成镜像
 

--- a/docs/zh/start/file/minio.md
+++ b/docs/zh/start/file/minio.md
@@ -6,9 +6,23 @@ Layotto提供了访问文件的示例 [demo](https://github.com/mosn/layotto/blo
 
 ### 第一步：启动layotto
 
-layotto提供了minio的配置文件[oss配置](https://github.com/mosn/layotto/blob/main/configs/config_file.json) ，如下图所示
+layotto提供了minio的配置文件[oss配置](https://github.com/mosn/layotto/blob/main/configs/config_file.json) ，如下所示
 
-![img.png](../../../img/file/minio.png)
+```
+                      "file": {
+                        "minioOSS": {
+                          "metadata":[
+                            {
+                              "endpoint": "play.min.io",
+                              "accessKeyID": "Q3AM3UQ867SPQQA43P2F",
+                              "accessKeySecret": "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG",
+                              "SSL":true,
+                              "region":"us-west-2"
+                            }
+                          ]
+                        }
+                      }
+```
 
 ### 第二步：启动MinIO服务
 访问[MinIO示例服务](play.min.io)

--- a/pkg/runtime/config.go
+++ b/pkg/runtime/config.go
@@ -40,11 +40,11 @@ type AppConfig struct {
 type MosnRuntimeConfig struct {
 	AppManagement          AppConfig                           `json:"app"`
 	HelloServiceManagement map[string]hello.HelloConfig        `json:"hellos"`
-	ConfigStoreManagement  map[string]configstores.StoreConfig `json:"config_stores"`
+	ConfigStoreManagement  map[string]configstores.StoreConfig `json:"config_store"`
 	RpcManagement          map[string]rpc.RpcConfig            `json:"rpcs"`
 	PubSubManagement       map[string]pubsub.Config            `json:"pub_subs"`
 	StateManagement        map[string]state.Config             `json:"state"`
-	Files                  map[string]file.FileConfig          `json:"files"`
+	Files                  map[string]file.FileConfig          `json:"file"`
 	LockManagement         map[string]lock.Config              `json:"lock"`
 	SequencerManagement    map[string]sequencer.Config         `json:"sequencer"`
 	Bindings               map[string]bindings.Metadata        `json:"bindings"`

--- a/pkg/runtime/config_test.go
+++ b/pkg/runtime/config_test.go
@@ -27,7 +27,7 @@ func TestConfig(t *testing.T) {
 					"hello": "greeting"
 					}
 				},
-				"files": {
+				"file": {
 					"aliOSS": {
                           "metadata":[
                             {

--- a/pkg/runtime/state/compatibility.go
+++ b/pkg/runtime/state/compatibility.go
@@ -28,7 +28,7 @@ const (
 	strategyAppid     = "appid"
 	strategyStoreName = "name"
 	strategyNone      = "none"
-	strategyDefault   = strategyAppid
+	strategyDefault   = strategyNone
 
 	daprSeparator = "||"
 )

--- a/pkg/runtime/state/compatibility_test.go
+++ b/pkg/runtime/state/compatibility_test.go
@@ -109,7 +109,7 @@ func TestDefaultPrefix(t *testing.T) {
 	var key = "state-key-1234567"
 
 	modifiedStateKey, _ := GetModifiedStateKey(key, "store3", "appid1")
-	require.Equal(t, "appid1||state-key-1234567", modifiedStateKey)
+	require.Equal(t, "state-key-1234567", modifiedStateKey)
 
 	originalStateKey := GetOriginalStateKey(modifiedStateKey)
 	require.Equal(t, key, originalStateKey)
@@ -139,7 +139,7 @@ func TestLegacyPrefix(t *testing.T) {
 	var key = "state-key-1234567"
 
 	modifiedStateKey, _ := GetModifiedStateKey(key, "store6", "appid1")
-	require.Equal(t, "appid1||state-key-1234567", modifiedStateKey)
+	require.Equal(t, "state-key-1234567", modifiedStateKey)
 
 	originalStateKey := GetOriginalStateKey(modifiedStateKey)
 	require.Equal(t, key, originalStateKey)
@@ -150,7 +150,7 @@ func TestPrefix_StoreNotInitial(t *testing.T) {
 
 	// no config for store999
 	modifiedStateKey, _ := GetModifiedStateKey(key, "store999", "appid99")
-	require.Equal(t, "appid99||state-key-1234567", modifiedStateKey)
+	require.Equal(t, "state-key-1234567", modifiedStateKey)
 
 	originalStateKey := GetOriginalStateKey(modifiedStateKey)
 	require.Equal(t, key, originalStateKey)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read contributing.md before commit pull request.
-->

**What this PR does**:
The configuration schema in `config.json` is changed: 
- `config_stores` -> `config_store`
- `files` -> `file`
- Change default state prefix strategy from `appid` to `none`

The previous default strategy `appid` will change the original key to `appid||key`. If users forget to add a strategy in their `config.json`, Layotto will modify all the keys written to backend DB, which is dangerous and pollutes the existing data.
So I think it's more appropriate to change the default strategy to `none`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The configuration schema in `config.json` is changed: 
- `config_stores` -> `config_store`
- `files` -> `file`
- Change default state prefix strategy from `appid` to `none`
```