### PR TITLE
fix: don't register apollo actuator when no apollo component configurated 

### DIFF
--- a/components/pkg/actuators/actutors_test.go
+++ b/components/pkg/actuators/actutors_test.go
@@ -1,0 +1,36 @@
+//
+// Copyright 2021 Layotto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package actuators
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestRangeAllIndicators(t *testing.T) {
+	readinessIndicator := NewHealthIndicator()
+	livenessIndicator := NewHealthIndicator()
+	indicators := &ComponentsIndicator{ReadinessIndicator: readinessIndicator, LivenessIndicator: livenessIndicator}
+	SetComponentsIndicator("test", indicators)
+	idc := GetIndicatorWithName("test")
+	assert.Equal(t, indicators, idc)
+	SetComponentsIndicator("test2", indicators)
+	cnt := 0
+	RangeAllIndicators(func(key string, value *ComponentsIndicator) bool {
+		cnt++
+		assert.Equal(t, indicators, value)
+		return true
+	})
+	assert.Equal(t, cnt, 2)
+}

--- a/components/pkg/actuators/indicator.go
+++ b/components/pkg/actuators/indicator.go
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-package apollo
+package actuators
 
 import (
-	"mosn.io/layotto/components/pkg/actuators"
 	"mosn.io/layotto/components/pkg/common"
 	"sync"
 )
@@ -26,34 +25,14 @@ const (
 	reasonKey = "reason"
 )
 
-var (
-	readinessIndicator *healthIndicator
-	livenessIndicator  *healthIndicator
-)
-
-func init() {
-	readinessIndicator = newHealthIndicator()
-	livenessIndicator = newHealthIndicator()
-	indicators := &actuators.ComponentsIndicator{ReadinessIndicator: readinessIndicator, LivenessIndicator: livenessIndicator}
-	actuators.SetComponentsIndicator("apollo", indicators)
-}
-
-func newHealthIndicator() *healthIndicator {
-	return &healthIndicator{
+func NewHealthIndicator() *HealthIndicator {
+	return &HealthIndicator{
 		started: false,
 		isErr:   false,
 	}
 }
 
-func GetReadinessIndicator() *healthIndicator {
-	return readinessIndicator
-}
-
-func GetLivenessIndicator() *healthIndicator {
-	return livenessIndicator
-}
-
-type healthIndicator struct {
+type HealthIndicator struct {
 	mu sync.Mutex
 
 	started   bool
@@ -61,7 +40,7 @@ type healthIndicator struct {
 	errReason string
 }
 
-func (idc *healthIndicator) Report() (status actuators.Status, details map[string]interface{}) {
+func (idc *HealthIndicator) Report() (status Status, details map[string]interface{}) {
 	idc.mu.Lock()
 	defer idc.mu.Unlock()
 	statusDetail := make(map[string]interface{})
@@ -77,7 +56,7 @@ func (idc *healthIndicator) Report() (status actuators.Status, details map[strin
 	return status, statusDetail
 }
 
-func (idc *healthIndicator) reportError(reason string) {
+func (idc *HealthIndicator) ReportError(reason string) {
 	idc.mu.Lock()
 	defer idc.mu.Unlock()
 
@@ -88,7 +67,7 @@ func (idc *healthIndicator) reportError(reason string) {
 	idc.errReason = reason
 }
 
-func (idc *healthIndicator) setStarted() {
+func (idc *HealthIndicator) SetStarted() {
 	idc.mu.Lock()
 	defer idc.mu.Unlock()
 

--- a/components/pkg/actuators/indicator_test.go
+++ b/components/pkg/actuators/indicator_test.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package apollo
+package actuators
 
 import (
 	"testing"
@@ -27,10 +27,10 @@ import (
 func TestGetHealthInitOrSuccess(t *testing.T) {
 	assert := testify.New(t)
 
-	hi := newHealthIndicator()
+	hi := NewHealthIndicator()
 	v, _ := hi.Report()
 	assert.Equal(v, common.INIT)
-	hi.setStarted()
+	hi.SetStarted()
 	h, _ := hi.Report()
 	assert.Equal(h, common.UP)
 }
@@ -38,8 +38,8 @@ func TestGetHealthInitOrSuccess(t *testing.T) {
 func TestGetHealthError(t *testing.T) {
 	assert := testify.New(t)
 
-	hi := newHealthIndicator()
-	hi.reportError("sub error")
+	hi := NewHealthIndicator()
+	hi.ReportError("sub error")
 	h, v := hi.Report()
 	assert.Equal(h, common.DOWN)
 	assert.Equal(v[reasonKey], "sub error")

--- a/components/sequencer/in-memory/in_memory_sequencer.go
+++ b/components/sequencer/in-memory/in_memory_sequencer.go
@@ -18,21 +18,45 @@ package in_memory
 
 import (
 	"go.uber.org/atomic"
+	"mosn.io/layotto/components/pkg/actuators"
 	"mosn.io/layotto/components/sequencer"
 	"sync"
 )
+
+var (
+	once               sync.Once
+	readinessIndicator *actuators.HealthIndicator
+	livenessIndicator  *actuators.HealthIndicator
+)
+
+const componentName = "in-memory"
+
+func init() {
+	readinessIndicator = actuators.NewHealthIndicator()
+	livenessIndicator = actuators.NewHealthIndicator()
+}
 
 type InMemorySequencer struct {
 	data *sync.Map
 }
 
+func registerActuator() {
+	once.Do(func() {
+		indicators := &actuators.ComponentsIndicator{ReadinessIndicator: readinessIndicator, LivenessIndicator: livenessIndicator}
+		actuators.SetComponentsIndicator(componentName, indicators)
+	})
+}
+
 func NewInMemorySequencer() *InMemorySequencer {
+	registerActuator()
 	return &InMemorySequencer{
 		data: &sync.Map{},
 	}
 }
 
 func (s *InMemorySequencer) Init(_ sequencer.Configuration) error {
+	readinessIndicator.SetStarted()
+	livenessIndicator.SetStarted()
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read contributing.md before commit pull request.
-->

**What this PR does**:
- don't register apollo actuator when no apollo component configurated 
- add actuator for in-memory sequencer component;

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #462 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```