### PR TITLE
ci: automatically upload binary files when releasing new version

### DIFF
--- a/.github/workflows/layotto-release.yml
+++ b/.github/workflows/layotto-release.yml
@@ -108,6 +108,16 @@ jobs:
           path: _output/darwin/amd64/layotto
           retention-days: 5
           if-no-files-found: error
+      - name: Compress Artifact
+        run: zip layotto.darwin_amd64.zip layotto
+        working-directory: _output/darwin/amd64
+      - name: Upload Artifact to Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: _output/darwin/amd64/layotto.darwin_amd64.zip
+          tag: ${{ github.ref }}
+
 
   build-binary-darwin-arm64-artifact:
     name:  "🧳 Darwin ARM64 Artifact"
@@ -130,6 +140,15 @@ jobs:
           path: _output/darwin/arm64/layotto
           retention-days: 5
           if-no-files-found: error
+      - name: Compress Artifact
+        run: zip layotto.darwin_arm64.zip layotto
+        working-directory: _output/darwin/arm64
+      - name: Upload Artifact to Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: _output/darwin/arm64/layotto.darwin_arm64.zip
+          tag: ${{ github.ref }}
 
   build-binary-linux-amd64-artifact:
     name:  "🧳 Linux AMD64 Artifact"
@@ -152,6 +171,15 @@ jobs:
           path: _output/linux/amd64/layotto
           retention-days: 5
           if-no-files-found: error
+      - name: Compress Artifact
+        run: zip layotto.linux_amd64.zip layotto
+        working-directory: _output/linux/amd64
+      - name: Upload Artifact to Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: _output/linux/amd64/layotto.linux_amd64.zip
+          tag: ${{ github.ref }}
 
   build-binary-linux-arm64-artifact:
     name:  "🧳 Linux ARM64 Artifact"
@@ -174,6 +202,15 @@ jobs:
           path: _output/linux/arm64/layotto
           retention-days: 5
           if-no-files-found: error
+      - name: Compress Artifact
+        run: zip layotto.linux_arm64.zip layotto
+        working-directory: _output/linux/arm64
+      - name: Upload Artifact to Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: _output/linux/arm64/layotto.linux_arm64.zip
+          tag: ${{ github.ref }}
 
   build-wasm-binary-linux-amd64-artifact:
     name:  "🧳 Linux AMD64 WASM Artifact"
@@ -197,6 +234,15 @@ jobs:
       #     path: _output/linux/amd64/layotto
       #     retention-days: 5
       #     if-no-files-found: error
+      # - name: Compress Artifact
+      #   run: zip layotto.wasm.linux_amd64.zip layotto
+      #   working-directory: _output/linux/amd64
+      # - name: Upload Artifact to Release
+      #   uses: svenstaro/upload-release-action@v2
+      #   with:
+      #     repo_token: ${{ secrets.GITHUB_TOKEN }}
+      #     file: _output/linux/amd64/layotto.wasm.linux_amd64.zip
+      #     tag: ${{ github.ref }}
 
   build-push-wasm-image:
     name:  "🎉 Linux AMD64 WASM Image"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read contributing.md before commit pull request.
-->

**What this PR does**:

Add a few steps in Layotto Release Pipeline so that binaries are auto uploaded to Release page when a new version is released.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #563 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```