### PR TITLE
fix: dead-link-checker can't find out dead links (#596)

### DIFF
--- a/.github/dead_link_check_config.json
+++ b/.github/dead_link_check_config.json
@@ -11,6 +11,9 @@
     },
     {
       "pattern": "^https://console.cloud.tencent.com/cos/bucket"
+    },
+    {
+      "pattern": "^#"
     }
   ],
   "replacementPatterns": [

--- a/.github/workflows/dead-link-checker.yaml
+++ b/.github/workflows/dead-link-checker.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install markdown-link-check
-        run: sudo npm install -g markdown-link-check@3.8.7
+        run: sudo npm install -g markdown-link-check@3
 
       - name: Install and start docsify server
         run: |

--- a/etc/script/check-dead-link.sh
+++ b/etc/script/check-dead-link.sh
@@ -1,3 +1,31 @@
+#!/usr/bin/env bash
+
+set -u
+
+NC='\033[0m' # No Color
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+
 for file in $(find . -name "*.md"); do
-  markdown-link-check -c .dlc.json -q "$file"
+  markdown-link-check -c .github/dead_link_check_config.json -q "$file" >> result.txt 2>&1
 done
+
+if [ -e result.txt ] ; then
+  cat result.txt
+  if grep -q "ERROR:" result.txt; then
+      echo -e "${YELLOW}=========================> MARKDOWN LINK CHECK RESULT<=========================${NC}"
+      printf "\n"
+      awk -F ' ' '/links checked/{sum+=$1}END{print "Total "sum" links checked.\n"}' result.txt
+      awk -F ' ' '/ERROR/{sum+=$2}END{print "[✖] Found "sum " dead links.\n"}' result.txt 
+      echo -e "${YELLOW}=========================================================================${NC}"
+      exit 2
+  else
+      echo -e "${YELLOW}=========================> MARKDOWN LINK CHECK RESULT<=========================${NC}"
+      printf "\n"
+      awk -F ' ' '/links checked/{sum+=$1}END{print "Total "sum" links checked.\n"}' result.txt
+      echo -e "${GREEN}[✔] All links are good!${NC}"
+      echo -e "${YELLOW}=========================================================================${NC}"
+  fi
+else
+  echo -e "${GREEN}No link need check!${NC}"
+fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read contributing.md before commit pull request.
-->

**What this PR does**:

1. update markdown-link-check version v3.8.7 -> v3

2. optimize check-dead-link result display

3. ignore internal anchor

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #596 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```