### PR TITLE
ci: make error message in "🌈 Go Style Check" more readable

### DIFF
--- a/make/common.mk
+++ b/make/common.mk
@@ -86,3 +86,9 @@ endif
 COMMA := ,
 SPACE :=
 SPACE +=
+
+# Colors
+NO_COLOR := \033[0m # No Color
+RED := \033[0;31m
+GREEN := \033[0;32m
+YELLOW := \033[0;33m

--- a/make/golang.mk
+++ b/make/golang.mk
@@ -114,7 +114,7 @@ go.test: go.test.verify
 .PHONY: go.style
 go.style:  
 	@echo "===========> Running go style check"
-	$(MAKE) format && git status && [[ -z `git status -s` ]]
+	$(MAKE) format && git status && [[ -z `git status -s` ]] || echo -e "\n${RED}Error: there are uncommitted changes after formatting all the code. ${GREEN}\nHow to fix it:${NO_COLOR} please 'make format' and then use git to commit all those changed files. "
 
 .PHONY: go.format.verify
 go.format.verify:  


### PR DESCRIPTION
Signed-off-by: seeflood <zhou.qunli@foxmail.com>

<!--  Thanks for sending a pull request!
Read contributing.md before commit pull request.
-->

**What this PR does**:
I spent some time telling @dzdx how to fix the CI error in https://github.com/mosn/layotto/pull/676 . 
It's not cool.
So I think we should make error message in "🌈 Go Style Check" more readable
![image](https://user-images.githubusercontent.com/26001097/176105927-0471ce9f-db66-44f2-8b2d-50166660d8f1.png)


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```