### PR TITLE
fix: ut unstable of zk lock

### DIFF
--- a/components/lock/zookeeper/zookeeper_lock.go
+++ b/components/lock/zookeeper/zookeeper_lock.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package zookeeper
 
 import (
@@ -24,7 +25,7 @@ import (
 	"mosn.io/layotto/components/pkg/utils"
 )
 
-// Zookeeper lock store
+// ZookeeperLock lock store
 type ZookeeperLock struct {
 	//trylock reestablish connection  every time
 	factory utils.ConnectionFactory
@@ -34,7 +35,7 @@ type ZookeeperLock struct {
 	logger     log.ErrorLogger
 }
 
-// Create ZookeeperLock
+//NewZookeeperLock Create ZookeeperLock
 func NewZookeeperLock(logger log.ErrorLogger) *ZookeeperLock {
 	lock := &ZookeeperLock{
 		logger: logger,
@@ -67,7 +68,7 @@ func (p *ZookeeperLock) Features() []lock.Feature {
 	return nil
 }
 
-// Node tries to acquire a zookeeper lock
+//TryLock Node tries to acquire a zookeeper lock
 func (p *ZookeeperLock) TryLock(req *lock.TryLockRequest) (*lock.TryLockResponse, error) {
 
 	conn, err := p.factory.NewConnection(time.Duration(req.Expire)*time.Second, p.metadata)
@@ -106,7 +107,7 @@ func (p *ZookeeperLock) TryLock(req *lock.TryLockRequest) (*lock.TryLockResponse
 
 }
 
-// Node tries to release a zookeeper lock
+//Unlock Node tries to release a zookeeper lock
 func (p *ZookeeperLock) Unlock(req *lock.UnlockRequest) (*lock.UnlockResponse, error) {
 
 	conn := p.unlockConn

--- a/components/lock/zookeeper/zookeeper_lock_test.go
+++ b/components/lock/zookeeper/zookeeper_lock_test.go
@@ -15,10 +15,11 @@
 package zookeeper
 
 import (
-	"mosn.io/layotto/components/pkg/utils"
 	"os"
 	"testing"
 	"time"
+
+	"mosn.io/layotto/components/pkg/utils"
 
 	"github.com/go-zookeeper/zk"
 	"github.com/golang/mock/gomock"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read contributing.md before commit pull request.
-->

**What this PR does**:
fix ut unstable of zookeeper lock, wait connection to close. 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #682 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```