### PR TITLE
ci: deadlink checker ignores https://docs.buf.build/

### DIFF
--- a/.github/dead_link_check_config.json
+++ b/.github/dead_link_check_config.json
@@ -13,6 +13,9 @@
       "pattern": "^https://console.cloud.tencent.com/cos/bucket"
     },
     {
+      "pattern": "^https://docs.buf.build/"
+    },
+    {
       "pattern": "^#"
     }
   ],


### PR DESCRIPTION
Signed-off-by: seeflood <zhou.qunli@foxmail.com>

<!--  Thanks for sending a pull request!
Read contributing.md before commit pull request.
-->

**What this PR does**:
Let the deadlink checker ignores https://docs.buf.build/

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes the CI error in #736 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```