### PR TITLE
chore: remove linters which is deprecated

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,9 +17,6 @@ linters :
     - gofmt
     - ineffassign
     - govet
-    - deadcode
-    - structcheck
-    - varcheck
     - typecheck
     - unconvert
     - staticcheck


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read contributing.md before commit pull request.
-->

**What this PR does**:

Warning from command `golangci-lint run ./...`

WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 