### PR TITLE
fix: make format and update command guide docs

### DIFF
--- a/docs/en/development/commands.md
+++ b/docs/en/development/commands.md
@@ -15,6 +15,10 @@ Layotto provides powerful commands, which makes contribution and local developme
 
 + Run `make license` to add licnese headers for all code files, with docker.
 
+> Notice: If you encounter the error "make[1]: *** No rule to make target 'all'. Stop.", it means that the Makefile cannot find this target.
+>
+> You should refer to the commands provided by `make help`. For example,  You can execute commands like `make lint` `make format` `make test` in place of `make all`, which you think should be used to checked codes locally.
+
 See below commands to know more details or excute `make help`:
 
 ```

--- a/docs/zh/development/commands.md
+++ b/docs/zh/development/commands.md
@@ -18,6 +18,10 @@ Layotto 提供了丰富的命令行工具，方便贡献者开发和测试 Layot
 
 + 执行 `make license` 使用 docker 容器为代码文件添加 license headers
 
+> 注意：使用时如遇到这个错误 "make[1]: *** No rule to make target 'all'.  Stop." ，说明 makefile 找不到对应的 target。
+> 
+> 这时你需要严格参考 `make help` 提供的指令，根据情况执行 `make lint` `make format` `make test` 等来替代 `make all`， 来达到本地检查代码的目的。
+
 具体细节可查看一下命令，或执行 `make help` 查看：
 
 ```

--- a/make/golang.mk
+++ b/make/golang.mk
@@ -28,7 +28,7 @@ ifeq ($(ROOT_PACKAGE),)
 	$(error the variable ROOT_PACKAGE must be set prior to including golang.mk)
 endif
 
-GOPATH := $(shell go env GOPATH)
+GOPATH := $(shell go env GOPATH | cut -d ':' -f 1)
 ifeq ($(origin GOBIN), undefined)
 	GOBIN := $(GOPATH)/bin
 endif


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read contributing.md before commit pull request.
-->

**What this PR does**:
1. Fix the problem of `make format`  not working well with multi go path.
2. Update docs in "commands guide". 

**Which issue(s) this PR fixes**:  #896
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
I found that gopath was not registered in the environment variables by default, so I still used the method provided in the original text in the issue to solve this bug


**Does this PR introduce a user-facing change?**: None