### PR TITLE
feat: change getobject default size from 100kb to 1M

### DIFF
--- a/pkg/grpc/dapr/dapr_api.go
+++ b/pkg/grpc/dapr/dapr_api.go
@@ -64,7 +64,7 @@ type daprGrpcAPI struct {
 	lockStores               map[string]lock.LockStore
 	sequencers               map[string]sequencer.Store
 	sendToOutputBindingFn    func(name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
-	secretStores             map[string]secretstores.SecretStore
+	GetSecretsecretStores    map[string]secretstores.SecretStore
 	// app callback
 	AppCallbackConn   *grpc.ClientConn
 	topicPerComponent map[string]TopicSubscriptions

--- a/pkg/grpc/dapr/dapr_api.go
+++ b/pkg/grpc/dapr/dapr_api.go
@@ -64,7 +64,7 @@ type daprGrpcAPI struct {
 	lockStores               map[string]lock.LockStore
 	sequencers               map[string]sequencer.Store
 	sendToOutputBindingFn    func(name string, req *bindings.InvokeRequest) (*bindings.InvokeResponse, error)
-	GetSecretsecretStores    map[string]secretstores.SecretStore
+	secretStores             map[string]secretstores.SecretStore
 	// app callback
 	AppCallbackConn   *grpc.ClientConn
 	topicPerComponent map[string]TopicSubscriptions


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read contributing.md before commit pull request.
-->

**What this PR does**:

Because there is a performance loss in the serialization of prtobuf, in order to reduce the performance loss of grpc in the oss scenario, the data size of each file transfer is increased to reduce the number of transmissions.